### PR TITLE
Spelling fixes for Bureaucracy

### DIFF
--- a/things.zil
+++ b/things.zil
@@ -2222,7 +2222,7 @@ takes your hand off with its sharp beak. You give up." CR>
 			     " couldn't
 move very fast, considering that it has only one wing; you would have been
 wrong. The damned thing has the speed, grace and tolerance of a shoal of
-pirhana fish, and after nearly losing your hand you side-step to safety. ">
+piranha fish, and after nearly losing your hand you side-step to safety. ">
 		       <COND (<IS? ,SHITMAIL ,SHITTY>
 			      <REMOVE ,SHITMAIL>
 			      <TELL "It then gobbles up the shreds of mail,">)

--- a/verbs.zil
+++ b/verbs.zil
@@ -3585,7 +3585,7 @@ stay right there." CR>
 	<TABLE (LENGTH PATTERN (BYTE [REST WORD]))
 	       #BYTE 0 
 	 "is not permitted in this story without prior written consent, in triplicate, from Infocom, Inc"
-	 "is a violation of the Cambridge Convention, which prohibits it in humourous games"
+	 "is a violation of the Cambridge Convention, which prohibits it in humorous games"
 	 "cannot be allowed until your bank acknowledges your change-of-address form"
 	 "may not be attempted by anyone using a computer"
 	 "is not permitted until you obtain your physician's approval, and submit Form 691/05/Z, in person, to the Office of Forms in Vladivostok">>


### PR DESCRIPTION
These are the spelling fixes for Bureaucracy from The ZIL Files. The usual caveats apply: I'm not a native English speaker, so please check that the fixes are correct.